### PR TITLE
Test for nuget directory before creation

### DIFF
--- a/Tasks/PSGalleryPublisher/PSGalleryPublisher/PSGalleryPublisher.ps1
+++ b/Tasks/PSGalleryPublisher/PSGalleryPublisher/PSGalleryPublisher.ps1
@@ -5,8 +5,11 @@ param(
 
 $nugetPath = "c:\nuget"
 
-Write-Verbose "Create C:\nuget folder"
-mkdir $nugetPath 
+# --- C:\nuget exists on VS2017 build agents. To avoid task failure, check whether the directory exists and only create if it doesn't/
+if (!(Test-Path -Path $nugetPath)) {
+    Write-Verbose "$nugetPath does not exist on this system. Creating directory."
+    New-Item -Path $nugetPath -ItemType Directory
+}
 
 Write-Verbose "Download Nuget.exe to C:\nuget"
 Invoke-WebRequest -Uri "http://go.microsoft.com/fwlink/?LinkID=690216&clcid=0x409" -OutFile $nugetPath\Nuget.exe


### PR DESCRIPTION
@kenakamu 
Currently this task fails on VS2017 agents because c:\nuget already exists. I've added a check for the directory which allows it to gracefully continue if we do not need to create the directory.